### PR TITLE
Fix recursive parsers with inputs not named "s"

### DIFF
--- a/nom-recursive-macros/src/lib.rs
+++ b/nom-recursive-macros/src/lib.rs
@@ -66,7 +66,7 @@ fn impl_recursive_parser_bofore(item: &ItemFn) -> Stmt {
                     use nom_tracable::Tracable;
                     nom_tracable::custom_trace(&#input, stringify!(#ident), "recursion detected", "\u{001b}[1;36m")
                 };
-                return Err(nom::Err::Error(nom::error::make_error(s, nom::error::ErrorKind::Fix)));
+                return Err(nom::Err::Error(nom::error::make_error(#input, nom::error::ErrorKind::Fix)));
             }
             #[cfg(feature = "trace")]
             {


### PR DESCRIPTION
Not naming the input of a `#[recursive_parser]` function `s` would cause an error like this:

```
  error[E0425]: cannot find value `s` in this scope
    --> nom-recursive/tests/test.rs:13:1
     |
  13 | #[recursive_parser]
     | ^^^^^^^^^^^^^^^^^^^ not found in this scope
     |
```

This fix properly uses `#ident` instead of hardcoded `s`.